### PR TITLE
Further typo fixes in tutorials

### DIFF
--- a/tutorial/11-tutorial.lisp
+++ b/tutorial/11-tutorial.lisp
@@ -1,26 +1,26 @@
 ;;; Creating code GUIs from scratch is great, but in the real world often design
-;;; is left to artists and code is left to engineers. CLOG is an amazign solution
-;;; for that model of app development. Any existing web page can be come a CLOG
+;;; is left to artists and code is left to engineers. CLOG is an amazing solution
+;;; for that model of app development. Any existing web page can become a CLOG
 ;;; app by simply adding the following two lines to an existing HTML file:
 ;;;
 ;;;      <script src="/js/jquery.min.js" type="text/javascript"></script>
 ;;;      <script src="/js/boot.js" type="text/javascript"></script>
 ;;;
 ;;; The first line adds jquery which CLOG uses to enhance browser compatability.
-;;; The second line add the "boot" file.
+;;; The second line adds the "boot" file.
 ;;;
-;;; For this tutorial we  generated the clog/static-files/tutorial/tut-11.html
+;;; For this tutorial we generated the clog/static-files/tutorial/tut-11.html
 ;;; by using the form generator at https://bootsnipp.com/forms?version=3
 ;;; then used the the template from https://getbootstrap.com/docs/3.3/
 ;;; and added CLOG's boot.js script line. It was neccesary to add an id to the
 ;;; form (id='form1') as the generator did not add one.
 ;;;
 ;;;  - We set a blank on-submit to overide the behavior in the bootstrap
-;;;          buttons to submit the from HTML style.
+;;;          buttons to submit the form HTML style.
 ;;;  - We are going to attach to the "Good Button" an on-click handler
 ;;;          to handle getting the values
 ;;;  - We attach to each control in the on-click handler that we want
-;;;          value for and query them
+;;;          a value for and query them
 ;;;  - We attach an on-click handler that resets the form to the
 ;;;          "Scary Button"
 ;;;
@@ -62,13 +62,13 @@
 	   (on-click-scary (obj)
 	     (declare (ignore obj))
 	     (reset form)))
-    ;; We need to overide the boostrap default to submit the form html style
+    ;; We need to override the boostrap default to submit the form html style
     (set-on-submit form (lambda (obj)(declare (ignore obj))()))
     (set-on-click good-button #'on-click-good)
     (set-on-click scary-button #'on-click-scary))
     (run body)))
 
 (defun start-tutorial ()
-  "Start turtorial."
+  "Start tutorial."
   (initialize #'on-new-window)
   (open-browser :url "http://127.0.0.1:8080/tutorial/tut-11.html"))

--- a/tutorial/12-tutorial.lisp
+++ b/tutorial/12-tutorial.lisp
@@ -1,14 +1,14 @@
 ;;; CLOG is an excellent choice for websites as well as GUI's for applications.
 ;;; The first 10 tutorials focused on a single "page" application. For GUIs
-;;; that works well and combining you CLOG app embedded in an native app that
+;;; that works well, and combining your CLOG app embedded in an native app that
 ;;; provides a web control on desktop or mobile works well. CLOG apps of course
-;;; are web apps right out of the box. However CLOG is also more then capable
+;;; are web apps right out of the box. However CLOG is also more than capable
 ;;; of handling things in a more traditional website manor.
 ;;;
 ;;; In the last tutorial it was demonstrated that one can take any HTML file
 ;;; add the boot.js file to it and then it becomes a dynamic interactive
 ;;; clog app. An entire site could be laid out using .html files and where
-;;; desired a full dynamic page can be created by copying the boot.html file
+;;; desired a fully dynamic page can be created by copying the boot.html file
 ;;; or some styled html template etc. (Look in the demos -coming soon- for
 ;;; examples using templates like bootstrap with CLOG, etc).
 ;;;
@@ -74,7 +74,7 @@
 	   (on-click-scary (obj)
 	     (declare (ignore obj))
 	     (reset form)))
-    ;; We need to overide the boostrap default to submit the form html style
+    ;; We need to override the boostrap default to submit the form html style
     (set-on-submit form (lambda (obj)(declare (ignore obj))()))
     (set-on-click good-button #'on-click-good)
     (set-on-click scary-button #'on-click-scary))
@@ -89,19 +89,19 @@
   ;; There is no .html file - it is just a route to CLOG handler
   ;; but the user thinks it is like any other html file.
   (set-on-new-window #'on-page1 :path "/page1.html")
-  ;; Here we add another page, page2. But uses a boot file that turns
+  ;; Here we add another page, page2. It uses a boot file that turns
   ;; on debugging to the browser console of communications with the
   ;; server.
   (set-on-new-window #'on-page2 :path "/page2" :boot-file "/debug.html")
   ;; Here we add another page, page3. But this time we use the html file
-  ;; from tutorial 11 and make it the boot-file and excute the same code
+  ;; from tutorial 11 and make it the boot-file and execute the same code
   ;; in (on-tutorial11) as in tutorial 11.
   (set-on-new-window #'on-tutorial11 :path "/page3"
 				     :boot-file "/tutorial/tut-11.html")
   ;; Setting a "default" path says that any use of an included boot.js
   ;; file will route to this function, in this case #'on-default
-  ;; that will determine if this is coming from the path used in tutorial
-  ;; 11 - "http://127.0.0.1:8080/tutorial/tut-11.html" and if does
-  ;; use on-tutorial11 and if not say "No Dice!"
+  ;; which will determine if this is coming from the path used in tutorial
+  ;; 11 - "http://127.0.0.1:8080/tutorial/tut-11.html" and if it does
+  ;; use on-tutorial11, and if not say "No Dice!"
   (set-on-new-window #'on-default :path "default")
   (open-browser))

--- a/tutorial/13-tutorial.lisp
+++ b/tutorial/13-tutorial.lisp
@@ -5,11 +5,11 @@
 (in-package :clog-user)
 
 (defun start-tutorial ()
-  "Start turtorial."
+  "Start tutorial."
   (format t "Tutorial 13 is a how to on building your own clog appliction.~%~
              Copy the directory - ~A~%~
              to your ~~/common-lisp directory or other asdf / quicklisp~%~
-             directory. Then follow the directions in the tuturial 13 ~%~
+             directory. Then follow the directions in the 13-tutorial ~%~
             directory."
-	  (merge-pathnames "./tutorial/tutorial13"
+	  (merge-pathnames "./tutorial/13-tutorial"
 			   (asdf:system-source-directory :clog))))


### PR DESCRIPTION
A few more trivial updates to comments and docstrings, for typo, small punctuation and grammar. for tutorials 11-13

I also corrected the directory name used in the tutorial 13 output to correspond to the directory name used in the repo.