### PR TITLE
Edits to the on page documentation for the tutorial 14

### DIFF
--- a/tutorial/14-tutorial.lisp
+++ b/tutorial/14-tutorial.lisp
@@ -29,9 +29,9 @@
        "<H1>Local Storage vs Session Storage</H1>
 <p width=500>
 The value of local storage persists in browser cache even after browser closed.
-If you reset this page the session storage key will remain the same, but openning
-in another window or tab will be a new session but if came from a click from this
-window the session keys are copied first to the new window.</p>
+If you reset this page the session and storage keys will remain the same, but
+opening in another window or tab will be a new session, but if it came from a
+click from this window the storage keys are copied first to the new window.</p>
 <br>
 <a href='.' target='_blank'>Another Window = Different Session</a><br>
 <br>


### PR DESCRIPTION
I'm not sure if the description of the behaviours is quite correct
where it is referring to 'session keys are copied first to the new
window'. When a new window is created, from the link the session key
is 'null', but the storage key is loaded from the previous value. This
behaviour is unsurprising, but diffent to the description, so I have
taken the liberty of changing the description so that it matches the
observed behaviour.

I'm submitting this one PR as distinct from the other typo commits, because it is changing editorial, and should be reviewed accordingly. 