### PR TITLE
Add link to GitHub Sponsors.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: rabbibotton


### PR DESCRIPTION
CLOG seems pretty fun. :)

Simply merge this pull request and enable the Sponsorships option in the [project's settings](https://github.com/rabbibotton/clog/settings) and you'll get the cool `Sponsor` button. Check [my fork](https://github.com/Hexstream/clog) for a preview.