### PR TITLE
Removing (print data) statement

### DIFF
--- a/source/clog-base.lisp
+++ b/source/clog-base.lisp
@@ -259,7 +259,6 @@ result or if time out DEFAULT-ANSWER (Private)"))
   "JavaScript to collect keyboard event data from browser.")
 
 (defun parse-keyboard-event (data)
-  (print data)
   (let ((f (ppcre:split ":" data)))
     (list
      :event-type :keyboard


### PR DESCRIPTION
Removing `(print data)` statement in `parse-keyboard-event`.
(used for debugging, I think)