### PR TITLE
Now all threads have their names.

### DIFF
--- a/tutorial/07-tutorial.lisp
+++ b/tutorial/07-tutorial.lisp
@@ -48,7 +48,8 @@
 		   (setf (text mover) ")-o-(")
 		   (sleep .2)
 		   (setf (text mover) "(-o-)"))
-	     (setf (inner-html mover) "<H1>GAME OVER</H1>")))
+	     (setf (inner-html mover) "<H1>GAME OVER</H1>"))
+           :name "Dragon event loop")
 	  ;; Check of browser still connected while running game loop
 	  (loop
 	    (unless (validp body)


### PR DESCRIPTION
It is better to pass `:name` parameter to every `bt:make-thread` call
because otherwise, all threads in the system will be like this:

    #<SB-THREAD:THREAD "Anonymous thread" RUNNING {1006295ED3}>

Anonymous threads make debugging harder :(

P.S. I also wanted to add a tutorial/app name to thread names but didn't find a proper way to store this name.