### PR TITLE
Fixing the function pass-by-value

### DIFF
--- a/source/clog-system.lisp
+++ b/source/clog-system.lisp
@@ -38,7 +38,11 @@ same as the clog directy this overides the relative paths used in them.")
       (if on-new-window
 	  (progn
 	    (setf (connection-data-item body "clog-body") body)
-	    (funcall on-new-window body))
+	    (funcall
+             (if (functionp on-new-window)
+                 on-new-window          ; in case you want to pass a lambda-expression
+                 (symbol-function on-new-window)) ; if you pass a symbol
+             body))
 	  (put-br (html-document body) "No route to on-new-window")))))
 
 (defun initialize

--- a/tutorial/01-tutorial.lisp
+++ b/tutorial/01-tutorial.lisp
@@ -37,7 +37,7 @@
   "Start turtorial."       ; Optional docstring to describe function
 
   ;; Initialize the CLOG system
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   ;; Set the function on-new-window to execute
   ;; everytime a browser connection to our app.
   ;; #' tells common lisp to pass the function

--- a/tutorial/02-tutorial.lisp
+++ b/tutorial/02-tutorial.lisp
@@ -38,5 +38,5 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/03-tutorial.lisp
+++ b/tutorial/03-tutorial.lisp
@@ -29,5 +29,5 @@
 ;;; set the even again when done handling the event if want to again accept the event.
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/04-tutorial.lisp
+++ b/tutorial/04-tutorial.lisp
@@ -19,5 +19,5 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/05-tutorial.lisp
+++ b/tutorial/05-tutorial.lisp
@@ -22,5 +22,5 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/06-tutorial.lisp
+++ b/tutorial/06-tutorial.lisp
@@ -33,5 +33,5 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/07-tutorial.lisp
+++ b/tutorial/07-tutorial.lisp
@@ -80,5 +80,5 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/08-tutorial.lisp
+++ b/tutorial/08-tutorial.lisp
@@ -102,5 +102,5 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/09-tutorial.lisp
+++ b/tutorial/09-tutorial.lisp
@@ -158,5 +158,5 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/10-tutorial.lisp
+++ b/tutorial/10-tutorial.lisp
@@ -23,5 +23,5 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/11-tutorial.lisp
+++ b/tutorial/11-tutorial.lisp
@@ -70,5 +70,5 @@
 
 (defun start-tutorial ()
   "Start tutorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser :url "http://127.0.0.1:8080/tutorial/tut-11.html"))

--- a/tutorial/12-tutorial.lisp
+++ b/tutorial/12-tutorial.lisp
@@ -86,26 +86,26 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-main)
+  (initialize 'on-main)
   ;; Navigating to http://127.0.0.1:8080/page1 executes on-page1
-  (set-on-new-window #'on-page1 :path "/page1")
+  (set-on-new-window 'on-page1 :path "/page1")
   ;; Navigating to http://127.0.0.1:8080/page1.html executes on-page1
   ;; There is no .html file - it is just a route to CLOG handler
   ;; but the user thinks it is like any other html file.
-  (set-on-new-window #'on-page1 :path "/page1.html")
+  (set-on-new-window 'on-page1 :path "/page1.html")
   ;; Here we add another page, page2. It uses a boot file that turns
   ;; on debugging to the browser console of communications with the
   ;; server.
-  (set-on-new-window #'on-page2 :path "/page2" :boot-file "/debug.html")
+  (set-on-new-window 'on-page2 :path "/page2" :boot-file "/debug.html")
   ;; Here we add another page, page3. But this time we use the html file
   ;; from tutorial 11 and make it the boot-file and execute the same code
   ;; in (on-tutorial11) as in tutorial 11.
-  (set-on-new-window #'on-tutorial11 :path "/page3"
+  (set-on-new-window 'on-tutorial11 :path "/page3"
 				     :boot-file "/tutorial/tut-11.html")
   ;; Setting a "default" path says that any use of an included boot.js
   ;; file will route to this function, in this case #'on-default
   ;; which will determine if this is coming from the path used in tutorial
   ;; 11 - "http://127.0.0.1:8080/tutorial/tut-11.html" and if it does
   ;; use on-tutorial11, and if not say "No Dice!"
-  (set-on-new-window #'on-default :path "default")
+  (set-on-new-window 'on-default :path "default")
   (open-browser))

--- a/tutorial/13-tutorial/hello-clog/hello-clog.lisp
+++ b/tutorial/13-tutorial/hello-clog/hello-clog.lisp
@@ -9,7 +9,7 @@
   (run body))
 
 (defun start-app ()
-  (initialize #'on-new-window
+  (initialize 'on-new-window
 	      :static-root (merge-pathnames "./www/"
 			     (asdf:system-source-directory :hello-clog)))
   (open-browser))

--- a/tutorial/14-tutorial.lisp
+++ b/tutorial/14-tutorial.lisp
@@ -52,5 +52,5 @@ Changes made to a local key will fire an event and print below:<br>"
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/15-tutorial.lisp
+++ b/tutorial/15-tutorial.lisp
@@ -28,5 +28,5 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/16-tutorial.lisp
+++ b/tutorial/16-tutorial.lisp
@@ -75,6 +75,6 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-index)
-  (set-on-new-window #'on-page2 :path "/page2")
+  (initialize 'on-index)
+  (set-on-new-window 'on-page2 :path "/page2")
   (open-browser))

--- a/tutorial/17-tutorial.lisp
+++ b/tutorial/17-tutorial.lisp
@@ -82,7 +82,7 @@
 
 (defun start-tutorial ()
   "Start tutorial."
-  (initialize #'on-index)
-  (set-on-new-window #'on-page2 :path "/page2")
-  (set-on-new-window #'on-page3 :path "/page3")
+  (initialize 'on-index)
+  (set-on-new-window 'on-page2 :path "/page2")
+  (set-on-new-window 'on-page3 :path "/page3")
   (open-browser))

--- a/tutorial/18-tutorial.lisp
+++ b/tutorial/18-tutorial.lisp
@@ -56,5 +56,5 @@
 
 (defun start-tutorial ()
   "Start tutorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/19-tutorial.lisp
+++ b/tutorial/19-tutorial.lisp
@@ -29,5 +29,5 @@
 
 (defun start-tutorial ()
   "Start tutorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/20-tutorial.lisp
+++ b/tutorial/20-tutorial.lisp
@@ -71,5 +71,5 @@
 
 (defun start-tutorial ()
   "Start tutorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/21-tutorial.lisp
+++ b/tutorial/21-tutorial.lisp
@@ -59,5 +59,5 @@ on the drop-root."))
 
 (defun start-tutorial ()
   "Start tutorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/22-tutorial.lisp
+++ b/tutorial/22-tutorial.lisp
@@ -159,5 +159,5 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/23-tutorial.lisp
+++ b/tutorial/23-tutorial.lisp
@@ -52,5 +52,5 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/24-tutorial.lisp
+++ b/tutorial/24-tutorial.lisp
@@ -104,5 +104,5 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/25-tutorial.lisp
+++ b/tutorial/25-tutorial.lisp
@@ -66,5 +66,5 @@
 
 (defun start-tutorial ()
   "Start turtorial."
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/26-tutorial.lisp
+++ b/tutorial/26-tutorial.lisp
@@ -99,7 +99,7 @@
 (defun start-tutorial ()
   "Start turtorial."
   ;; We would probably set :host to my IP and :port 80 here if running a live site
-  (initialize #'on-new-window)
+  (initialize 'on-new-window)
   ;; In real life, if we openning a browser here it would likely be
   ;; to a monitor of system etc.
   (open-browser))


### PR DESCRIPTION
Recompiling the on-new-window handler requires you to also recompile the form (initialize #'on-new-window).
I haven't done any tests, But from what I can tell, the fix works.