### PR TITLE
update manual to refer to package containing run-tutorial

### DIFF
--- a/doc/clog-manual.html
+++ b/doc/clog-manual.html
@@ -131,7 +131,7 @@ have Quicklisp configured):</p>
 </ol>
 
 <pre><code><span class="code">CL-USER&gt; <span class="paren1">(<span class="code">ql:quickload <span class="keyword">:clog</span></span>)</span>
-CL-USER&gt; <span class="paren1">(<span class="code">clog-user:run-tutorial 1</span>)</span></span></code></pre>
+CL-USER&gt; <span class="paren1">(<span class="code">clog:run-tutorial 1</span>)</span></span></code></pre>
 
 <p>To see where the source files are:</p>
 


### PR DESCRIPTION
I followed the instructions and found that `(clog-user:run-tutorial 1)` didn't work, but `(clog:run-tutorial 1)` did, so here is a pull request to fix the docs.