### PR TITLE
fix typo in clog-manual.html

### DIFF
--- a/doc/clog-manual.html
+++ b/doc/clog-manual.html
@@ -99,7 +99,7 @@ embedded in a native template application.)</p>
 such as full desktop over the web, database tools,etc. See below for
 some enhacements being worked on. CLOG is actually based on GNOGA, a
 framework I wrote for Ada in 2013 and used in commercial production
-code for the last 8+ years, i.e. the techiniques CLOG uses are solid
+code for the last 8+ years, i.e. the techniques CLOG uses are solid
 and proven.</p>
 
 <p>CLOG is being actively extended daily. Check the github discussion


### PR DESCRIPTION
Thanks for making this project!
I found a typo here.
Proposal is changing the word "techiniques" to techniques.