### PR TITLE
Use special variable clog auth key

### DIFF
--- a/source/clog-auth.lisp
+++ b/source/clog-auth.lisp
@@ -75,10 +75,10 @@ for CLOG")
   (check-type body clog-body)
   (set-on-storage (window body) (lambda (obj data)
                                   (declare (ignore obj))
-				  (set-on-storage (window body) nil)
-				  (when (equalp (getf data :key)
-						*clog-auth-key*)
-				    (funcall handler body)))))
+                                  (set-on-storage (window body) nil)
+                                  (when (equalp (getf data :key)
+                                                *clog-auth-key*)
+                                    (funcall handler body)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Implementation - clog-auth - Authorization

--- a/source/clog-auth.lisp
+++ b/source/clog-auth.lisp
@@ -75,10 +75,10 @@ for CLOG")
   (check-type body clog-body)
   (set-on-storage (window body) (lambda (obj data)
                                   (declare (ignore obj))
-                                  (set-on-storage (window body) nil)
-                                  (when (equalp (getf data :key)
-                                                "clog-auth-token")
-                                    (funcall handler body)))))
+				  (set-on-storage (window body) nil)
+				  (when (equalp (getf data :key)
+						*clog-auth-key*)
+				    (funcall handler body)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Implementation - clog-auth - Authorization


### PR DESCRIPTION
All the other ```"clog-auth-token"``` are the values of the same parameter ```*clog-auth-key*```.
We should probably make them consistent for SSOT.