### PR TITLE
Add `with-repl` option to `set-on-new-window` for additional REPL functionality

### DIFF
--- a/source/clog-helpers.lisp
+++ b/source/clog-helpers.lisp
@@ -104,9 +104,9 @@ set (logging to browser console), "
                        (when clog-web-initialize
                          (clog-web:clog-web-initialize body))
                        (when clog-gui-initialize
-                         (clog-gui:clog-gui-initialize body))
-                       (setf clog-user::*body* body))
-                     :path "/repl")
+                         (clog-gui:clog-gui-initialize body)))
+                     :path "/repl"
+                     :with-repl t)
   (open-browser :url "http://127.0.0.1:8080/repl")
   (format t "Use clog-user:*body* to access the clog-repl window."))
 

--- a/tools/clog-builder.lisp
+++ b/tools/clog-builder.lisp
@@ -2322,7 +2322,7 @@ of controls and double click to select control."
         (create-br body)
         (create-div body :content (format nil "For example:<br>(create-img body :url-src \"~A\")" pic-data))))))
 
-(defun clog-builder (&key (port 8080) static-root system)
+(defun clog-builder (&key (port 8080) static-root system with-repl)
   "Start clog-builder."
   (if system
       (setf static-root (merge-pathnames "./www/"
@@ -2330,9 +2330,9 @@ of controls and double click to select control."
   (if static-root
       (initialize nil :port port :static-root static-root)
       (initialize nil :port port))
-  (set-on-new-window 'on-new-builder :path "/builder")
-  (set-on-new-window 'on-new-db-admin :path "/dbadmin")
-  (set-on-new-window 'create-sys-browser :path "/sysbrowser")
-  (set-on-new-window 'on-attach-builder-page :path "/builder-page")
-  (set-on-new-window 'on-convert-image :path "/image-to-data")
+  (set-on-new-window 'on-new-builder :path "/builder" :with-repl with-repl)
+  (set-on-new-window 'on-new-db-admin :path "/dbadmin" :with-repl with-repl)
+  (set-on-new-window 'create-sys-browser :path "/sysbrowser" :with-repl with-repl)
+  (set-on-new-window 'on-attach-builder-page :path "/builder-page" :with-repl with-repl)
+  (set-on-new-window 'on-convert-image :path "/image-to-data" :with-repl with-repl)
   (open-browser :url (format nil "http://127.0.0.1:~A/builder" port)))


### PR DESCRIPTION
Example usage:
```Lisp
CLOG-USER> (clog-tools:clog-builder :with-repl t)
CLOG-USER> (setf (background-color (gethash "/builder" clog::*repl-bodies*)) "blue")
```
- [X] Feature implemented
- [ ] Should `CLOG-USER::*BODY*` be removed
- [ ] Has all code for properly cleaning up been addressed