### PR TITLE
Handling living ws connections after CLOG:SHUTDOWN as well as related modifications

### DIFF
--- a/clog.asd
+++ b/clog.asd
@@ -6,40 +6,42 @@
   :license  "BSD"
   :version "1.6.0"
   :serial t
-  :pathname "source/"
   :depends-on (#:clack #:websocket-driver #:alexandria #:hunchentoot #:cl-ppcre
-               #:bordeaux-threads #:trivial-open-browser #:parse-float #:quri
-               #:lack-middleware-static #:lack-request #:lack-util-writer-stream
-               #:closer-mop #:mgl-pax #:cl-template
-               #:sqlite #:cl-dbi #:cl-pass #:cl-isaac)
-  :components ((:file "asdf-ext")
-               (:file "clog-connection")
-               (:file "clog")
-               (:file "clog-utilities")
-               (:file "clog-base")
-               (:file "clog-element")
-               (:file "clog-jquery")
-               (:file "clog-element-common")
-               (:file "clog-style")
-               (:file "clog-canvas")
-               (:file "clog-form")
-               (:file "clog-multimedia")
-               (:file "clog-window")
-               (:file "clog-document")
-               (:file "clog-location")
-               (:file "clog-navigator")
-               (:file "clog-body")
-               (:file "clog-system")
-               (:file "clog-panel")
-               (:file "clog-presentations")
-               (:file "clog-data")
-               (:file "clog-dbi")
-               (:file "clog-auth")
-               (:file "clog-gui")
-               (:file "clog-web")
-               (:file "clog-web-dbi")
-               (:file "clog-web-themes")
-               (:file "clog-helpers")))
+                       #:bordeaux-threads #:trivial-open-browser #:parse-float #:quri
+                       #:lack-middleware-static #:lack-request #:lack-util-writer-stream
+                       #:closer-mop #:mgl-pax #:cl-template
+                       #:sqlite #:cl-dbi #:cl-pass #:cl-isaac)
+  :components ((:module "static-files"
+                :components ((:static-file "js/boot.js")))
+               (:module "source"
+                :components ((:file "asdf-ext")
+                             (:file "clog-connection")
+                             (:file "clog")
+                             (:file "clog-utilities")
+                             (:file "clog-base")
+                             (:file "clog-element")
+                             (:file "clog-jquery")
+                             (:file "clog-element-common")
+                             (:file "clog-style")
+                             (:file "clog-canvas")
+                             (:file "clog-form")
+                             (:file "clog-multimedia")
+                             (:file "clog-window")
+                             (:file "clog-document")
+                             (:file "clog-location")
+                             (:file "clog-navigator")
+                             (:file "clog-body")
+                             (:file "clog-system")
+                             (:file "clog-panel")
+                             (:file "clog-presentations")
+                             (:file "clog-data")
+                             (:file "clog-dbi")
+                             (:file "clog-auth")
+                             (:file "clog-gui")
+                             (:file "clog-web")
+                             (:file "clog-web-dbi")
+                             (:file "clog-web-themes")
+                             (:file "clog-helpers")))))
 
 (asdf:defsystem #:clog/docs
   :depends-on (#:clog #:3BMD #:colorize)

--- a/source/clog-connection.lisp
+++ b/source/clog-connection.lisp
@@ -205,6 +205,13 @@ the default answer. (Private)"
   (handler-case
       (cond ((and id (gethash id *connection-data*))
              (format t "Reconnection id - ~A to ~A~%" id connection)
+             (handler-case
+                 (websocket-driver:close-connection (gethash id *connection-ids*)
+                                                    "Aborting this old connection since receiving a reconnection request.")
+               (t (c)
+                 (when *verbose-output*
+                   (format t "Failed to close the old connection when establishing reconnection. This can be normal: The old connection could probably don't work for the client, so the client is requesting to reconnect.~%Condition - ~A.~&"
+                           c))))
              (setf (gethash id *connection-ids*) connection)
              (setf (gethash connection *connections*) id))
             (t

--- a/source/clog-connection.lisp
+++ b/source/clog-connection.lisp
@@ -241,7 +241,13 @@ the default answer. (Private)"
   (handler-case
       (let ((connection-id (gethash connection *connections*))
             (ml (ppcre:split ":" message :limit 2)))
-        (cond ((equal (first ml) "0")
+        (cond ((null connection-id)
+               ;; a zombie connection
+               (when *verbose-output*
+                 (format t "A zombie connection ~A. CLOG doesn't remember its connection-id. Closing it.~%"
+                         connection))
+               (websocket-driver:close-connection connection)) ; don't send the reason for better security
+              ((equal (first ml) "0")
                ;; a ping
                (when *verbose-output*
                  (format t "Connection ~A    Ping~%" connection-id)))

--- a/source/clog-connection.lisp
+++ b/source/clog-connection.lisp
@@ -214,6 +214,9 @@ the default answer. (Private)"
                            c))))
              (setf (gethash id *connection-ids*) connection)
              (setf (gethash connection *connections*) id))
+            (id
+             (format t "Reconnection id ~A not found. Closing the connection.~%" id)
+             (websocket-driver:close-connection connection)) ; Don't send the reason for better security.
             (t
              (setf id (random-hex-string))
              (setf (gethash connection *connections*) id)

--- a/source/clog-connection.lisp
+++ b/source/clog-connection.lisp
@@ -203,7 +203,7 @@ the default answer. (Private)"
 (defun handle-new-connection (connection id)
   "Handle new incoming websocket CONNECTIONS with ID from boot page. (Private)"
   (handler-case
-      (cond (id
+      (cond ((and id (gethash id *connection-data*))
              (format t "Reconnection id - ~A to ~A~%" id connection)
              (setf (gethash id *connection-ids*) connection)
              (setf (gethash connection *connections*) id))

--- a/static-files/js/boot.js
+++ b/static-files/js/boot.js
@@ -64,16 +64,21 @@ function Setup_ws() {
     }
 
     ws.onclose = function (event) {
-        console.log ('onclose: reconnect');
-        ws = null;
-        ws = new WebSocket (adr + '?r=' + clog['connection_id']);
-        ws.onopen = function (event) {
-            console.log ('onclose: reconnect successful');
-            Setup_ws();
-        }
-        ws.onclose = function (event) {
-            console.log ('onclose: reconnect failure');
+        if (event.code && event.code === 1000) {
+            console.log("WebSocket connection got normal close from server. Don't reconnect.");
             Shutdown_ws(event);
+        } else {
+            console.log ('onclose: reconnect');
+            ws = null;
+            ws = new WebSocket (adr + '?r=' + clog['connection_id']);
+            ws.onopen = function (event) {
+                console.log ('onclose: reconnect successful');
+                Setup_ws();
+            }
+            ws.onclose = function (event) {
+                console.log ('onclose: reconnect failure');
+                Shutdown_ws(event);
+            }
         }
     }
 }

--- a/static-files/js/boot.js
+++ b/static-files/js/boot.js
@@ -1,4 +1,3 @@
-/*static version*/
 var ws=null;
 var adr; var adrc;
 var clog={};


### PR DESCRIPTION
# Brief
1. Code maintainability of boot-js.
2. Let WebSocket servers close those connections whose clients don't provide a proper connection-id.

## Code maintainability of boot-js.
### Done in [SSOT for compiled boot-js and base version of js/boot.js](https://github.com/rabbibotton/clog/commit/b5c8e3a1655cedf8db4b26b59e403307059f6119)
1. SSOT for [compiled-boot-js](https://github.com/rabbibotton/clog/blob/a70e84a062dc39a9fea23a380e870ecaa1b7c03f/source/clog-connection.lisp#L718) and [static-files/js/boot.js](https://github.com/rabbibotton/clog/blob/a70e84a062dc39a9fea23a380e870ecaa1b7c03f/static-files/js/boot.js). They are currently 100% the same. (except for the first line comment ```/*static version*/``` VS. ```/*compiled version*/```, of course). 
2. Better to separate js code to js files if possible. Editors can recognize them for many benefits.
### Done in [have asdf watch file changed of boot.js in clog system source](https://github.com/rabbibotton/clog/commit/bac9553bbe21b00e76cfffd896596d7d5ccef9a0)
Having asdf watch file change of boot.js in clog system source, so asdf and quickload will reload the system if needed.
##  Let WebSocket servers close those connections whose clients don't provide a proper connection-id.
1. Let a WebSocket server closes the connection if there's no corresponding connection-id.
2. Let a WebSocket server closes the connection if the client wants to reconnect with an invalid connection-id.
3. Let the client (default boot.js) stop reconnecting if the server closes the connection with a normal clause.
###  More about letting a WebSocket server closes the connection if there's no corresponding connection-id.
After ```(clog:shutdown)```, established WebSocket connections are somehow still alive. They occupy computation & memory resources.
```lisp
Connection b65ae6f45e44ee4992a5bec4eeed04e8    Ping

CL-USER> (clog:shutdown)
NIL
Connection NIL    Ping  
Connection NIL    Ping
Connection NIL    Ping  ; the connection is somehow still alive
```
The result of [Close zombie websocket connection](https://github.com/rabbibotton/clog/commit/e0aeae7690265caff18a29987bfb7bf76876b50c)
```lisp
CL-USER> clog-connection:*verbose-output*
T
Connection cb39d163104ce9fbc6b6b43684be8bdc    Ping
Connection cb39d163104ce9fbc6b6b43684be8bdc    Ping
CL-USER> (clog:shutdown)
NIL
A zombie connection #<SERVER {7017AA7DF3}>. CLOG doesn't remember its connection-id. Closing it.
```
This should be seen as a **temporary** solution because ideally ```(clog:shutdown)``` should have completed the job.
 