### PR TITLE
More control over automatic placement

### DIFF
--- a/source/clog-base.lisp
+++ b/source/clog-base.lisp
@@ -833,13 +833,14 @@ event on right click."))
 is nil unbind the event. Setting this event will replace an on-mouse click if
 set. If :ONE-TIME unbind event on click."))
 
-(defmethod set-on-click ((obj clog-obj) handler &key (one-time nil))
+(defmethod set-on-click ((obj clog-obj) handler &key one-time cancel-event)
   (set-event obj "click"
              (when handler
                (lambda (data)
                  (declare (ignore data))
                  (funcall handler obj)))
-             :one-time one-time))
+             :one-time one-time
+	     :cancel-event cancel-event))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; set-on-double-click ;;

--- a/source/clog-element.lisp
+++ b/source/clog-element.lisp
@@ -87,7 +87,10 @@ CLOG-OBJ. If HTML-ID is nil one will be generated."))
                                  :clog-type clog-type
                                  :html-id   html-id)))
     (if auto-place
-        (place-inside-bottom-of obj child)
+        (case auto-place
+	  (:bottom (place-inside-bottom-of obj child))
+	  (:top (place-inside-top-of obj child))
+	  (t (place-inside-bottom-of obj child)))
         child)))
 
 ;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
- create-child accepts `:bottom` and `:top` as spec for auto-placement.
- pass cancel-event in set-on-click, if you don't mind.