### PR TITLE
Remove errant tilde at end of line.

### DIFF
--- a/source/clog-window.lisp
+++ b/source/clog-window.lisp
@@ -481,7 +481,7 @@ The data parementer of the event function contains the time stamp
 to the millisecond."))
 
 (defmethod request-animation-frame ((obj clog-window))
-  (execute obj (format nil "requestAnimationFrame(function (s) ~
+  (execute obj (format nil "requestAnimationFrame(function (s)
                              {~A.trigger('clog-animate', s)})"
                        (jquery obj))))
 


### PR DESCRIPTION
This is my proposed fix for #269
The error requires CRLF line ends which is especially odd that white space makes this big a difference but it seems to in this case. Without this SBCL fails to load clog-window.lisp but the ~ at the end of line in a format string is still an obvious error.
The fix is to remove errant tilde.