### PR TITLE
follow up on PAX changes

### DIFF
--- a/source/clog.lisp
+++ b/source/clog.lisp
@@ -20,6 +20,11 @@
 
 (cl:in-package :clog)
 
+(defmethod exportable-reference-p ((package (eql (find-package :clog)))
+                                   symbol (locative-type (eql 'section))
+                                   locative-args)
+  t)
+
 (defsection @clog-manual (:title "The CLOG manual")
   "The Common Lisp Omnificient GUI, CLOG for short, uses web technology to
 produce graphical user interfaces for applications locally or remotely.
@@ -351,6 +356,8 @@ embedded in a native template application.)"
   (font-variant-type          type)
   (system-font-type           type)
   (font                       generic-function)
+  ;; This is not defined.
+  #+nil
   (font-css                   generic-function)
   (set-font                   generic-function)
   (text-alignment-type        type)


### PR DESCRIPTION
In e0b7417, PAX was changed to *not* exporting SECTIONs and GLOSSARY-TERMs by default (see MGL-PAX:EXPORTABLE-REFERENCE-P). Following the example in the PAX documentation, this change makes the package CLOG export symbols naming SECTIONs to get the old behavior and make documentation generation work again.

Expanding on that, this may not be the right solution for CLOG. The default was changed because in most cases the names of sections are not part of the contract (i.e. they are subject to change) and exporting them can lead to package conflicts. Plus, with the @SECTION-NAME naming convention, one can list e.g. all PAX sections by typing "PAX::@" and pressing TAB in Slime.