### PR TITLE
Try to use the default answer instead of `undefined'.

### DIFF
--- a/source/clog-connection.lisp
+++ b/source/clog-connection.lisp
@@ -299,7 +299,9 @@ the default answer. (Private)"
                            server-query-id
                            'browser-returned-answer
                            browser-returned-answer))
-                 (setf (gethash (parse-integer server-query-id) *queries*) browser-returned-answer)
+                 ;; Try to use the default answer instead of `undefined'.
+                 (unless (string= "undefined" browser-returned-answer)
+                   (setf (gethash (parse-integer server-query-id) *queries*) browser-returned-answer))
                  (bordeaux-threads:signal-semaphore
                   (gethash (parse-integer server-query-id) *queries-sems*))))))
     (t (c)


### PR DESCRIPTION
For instance, if the call to **(width win**) were to return nil instead of the default value 0, it could lead to exceptions when performing arithmetic operations.