### PR TITLE
Updated all Tutorials to have a standardized page title.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 ### License BSD 3-Clause License
 
+zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+
+
 View the HTML Documentation:
 
 https://rabbibotton.github.io/clog/clog-manual.html

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 
 ### License BSD 3-Clause License
 
-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
-
-
 View the HTML Documentation:
 
 https://rabbibotton.github.io/clog/clog-manual.html

--- a/tutorial/01-tutorial.lisp
+++ b/tutorial/01-tutorial.lisp
@@ -9,6 +9,8 @@
 (defun on-new-window (body)           ; Define the function called on-new-window
   "On-new-window handler."            ; Optional docstring to describe function
 
+  (setf (title (html-document body)) "Tutorial 01") ;; set the page title
+
   (let ((hello-element                ; hello-element is a local variable that
                                       ; will be bound to our new CLOG-Element
 

--- a/tutorial/02-tutorial.lisp
+++ b/tutorial/02-tutorial.lisp
@@ -7,7 +7,7 @@
 (defun on-new-window (body)
   "On-new-window handler."
   ;; Give your app a name that appears in the browser tab/window
-  (setf (title (html-document body)) "Tutorial 2")
+  (setf (title (html-document body)) "Tutorial 02")
   ;; The CLOG-body object gives you access to a number of other CLOG-Objects
   ;;
   ;; (html-document body) is the CLOG-Document object ~ These are aproximately

--- a/tutorial/03-tutorial.lisp
+++ b/tutorial/03-tutorial.lisp
@@ -6,7 +6,7 @@
 
 (defun on-new-window (body)
   "On-new-window handler."
-  (setf (title (html-document body)) "Tutorial 3")
+  (setf (title (html-document body)) "Tutorial 03")
   (let ((hello-element
           (create-section body :h1 :content "Hello World! (click me!)")))
     (let ((x 0))

--- a/tutorial/04-tutorial.lisp
+++ b/tutorial/04-tutorial.lisp
@@ -9,7 +9,7 @@
                                      ; RGB is a helper function for color
 (defun on-new-window (body)
   "On-new-window handler."
-  (setf (title (html-document body)) "Tutorial 4")
+  (setf (title (html-document body)) "Tutorial 04")
   ;; The same handler #'my-on-click is set on both targets
   (set-on-click (create-section body :h1 :content "Hello World! (click me!)")
                 'my-on-click)

--- a/tutorial/05-tutorial.lisp
+++ b/tutorial/05-tutorial.lisp
@@ -13,7 +13,7 @@
 
 (defun on-new-window (body)
   "On-new-window handler."
-  (setf (title (html-document body)) "Tutorial 5")
+  (setf (title (html-document body)) "Tutorial 05")
   (set-on-click (create-section body :h1 :content "Hello World! (click me!)")
                 'my-on-click)
   (setf (connection-data-item body "changer")

--- a/tutorial/06-tutorial.lisp
+++ b/tutorial/06-tutorial.lisp
@@ -26,7 +26,7 @@
 
 (defun on-new-window (body)
   "On-new-window handler."
-  (setf (title (html-document body)) "Tutorial 6")
+  (setf (title (html-document body)) "Tutorial 06")
   (set-on-click (create-section body :h1 :content "(click me to start!)")
                 'my-on-click))
 

--- a/tutorial/07-tutorial.lisp
+++ b/tutorial/07-tutorial.lisp
@@ -12,7 +12,7 @@
 (defun on-new-window (body)
   (handler-case   ; Disconnects from the browser can be handled gracefully using the condition system.
       (progn
-        (setf (title (html-document body)) "Tutorial 7")
+        (setf (title (html-document body)) "Tutorial 07")
         ;; Show a "splash" screen
         (setf (hiddenp (prog1
                            (create-section body :h2

--- a/tutorial/08-tutorial.lisp
+++ b/tutorial/08-tutorial.lisp
@@ -62,7 +62,7 @@
 (defun on-new-window (body)
   (let ((app (make-instance 'app-data)))                 ; Create our "App-Data" for this instance
     (setf (connection-data-item body "app-data") app))   ; of our App.
-  (setf (title (html-document body)) "Tutorial 8")
+  (setf (title (html-document body)) "Tutorial 08")
   (let* ((div1 (create-div body))
          (div2 (create-div div1))
          (div3 (create-div div2))

--- a/tutorial/09-tutorial.lisp
+++ b/tutorial/09-tutorial.lisp
@@ -5,7 +5,7 @@
 (in-package :clog-tut-9)
 
 (defun on-new-window (body)
-  (setf (title (html-document body)) "Tutorial 9")
+  (setf (title (html-document body)) "Tutorial 09")
   ;; When doing extensive setup of a page using connection cache
   ;; reduces rountrip traffic and speeds setup.
   (with-connection-cache (body)

--- a/tutorial/11-tutorial.lisp
+++ b/tutorial/11-tutorial.lisp
@@ -36,7 +36,7 @@
 (in-package :clog-tut-11)
 
 (defun on-new-window (body)
-  ;; This will turn on debug output in the browser console.
+    ;; This will turn on debug output in the browser console.
   (debug-mode body)
   ;; Setup form
   (let* ((form         (attach-as-child body "form1" :clog-type 'clog-form))
@@ -67,7 +67,12 @@
     ;; We need to override the boostrap default to submit the form html style
     (set-on-submit form (lambda (obj)(declare (ignore obj))()))
     (set-on-click good-button #'on-click-good)
-    (set-on-click scary-button #'on-click-scary))))
+    (set-on-click scary-button #'on-click-scary)))
+
+  (setf (title (html-document body)) "Tutorial 11") ;; set the page title
+
+  
+  )
 
 (defun start-tutorial ()
   "Start tutorial."

--- a/tutorial/12-tutorial.lisp
+++ b/tutorial/12-tutorial.lisp
@@ -24,6 +24,7 @@
 (in-package :clog-tut-12)
 
 (defun on-main (body)
+  (setf (title (html-document body)) "Tutorial 12") ;; set the page title
   (let ((sb (create-style-block body)))
     (add-style sb :element "a"       '(("color"           :orange)
                                        ("text-decoration" :none)))

--- a/tutorial/15-tutorial.lisp
+++ b/tutorial/15-tutorial.lisp
@@ -6,6 +6,7 @@
 
 ;;; Brief demonstration of multimedia
 (defun on-new-window (body)
+  (setf (title (html-document body)) "Tutorial 15") ;; set the page title
   (let* ((vid (create-video body :source "https://www.w3schools.com/html/mov_bbb.mp4"))
          (tmp (create-br body))
          (vpl (create-button body :content ">"))

--- a/tutorial/16-tutorial.lisp
+++ b/tutorial/16-tutorial.lisp
@@ -14,7 +14,7 @@
   (load-script (html-document body) "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js")
   (load-script (html-document body) "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js")
   ;; Root page setup
-  (setf (title (html-document body)) "Hello Boostrap")
+  (setf (title (html-document body)) "Tutorial 16: Hello Boostrap")
   (let* ((nav   (create-section body :nav :class "nav"))
          ;; Nav Bar
          (l1    (create-a nav :content "link1" :class "nav-link"))

--- a/tutorial/17-tutorial.lisp
+++ b/tutorial/17-tutorial.lisp
@@ -13,7 +13,7 @@
   (load-css (html-document body) "https://www.w3schools.com/w3css/4/w3.css")
   (load-css (html-document body) "https://www.w3schools.com/lib/w3-theme-teal.css")
   ;; Setup page
-  (setf (title (html-document body)) "Hello W3.CSS")
+  (setf (title (html-document body)) "Tutorial 17: Hello W3.CSS")
   (let* ((header (create-section body :header :class "w3-container w3-card w3-theme"))
          (tmp    (create-section header :h1 :content "Explore Forms"))
          ;; Main area of page

--- a/tutorial/18-tutorial.lisp
+++ b/tutorial/18-tutorial.lisp
@@ -6,6 +6,7 @@
 
 ;; Demonstrate drag and drop
 (defun on-new-window (body)
+  (setf (title (html-document body)) "Tutorial 18") ;; set the page title
   (let* ((target1 (create-div body))
          (target2 (create-div body))
          (object  (create-div target1))

--- a/tutorial/19-tutorial.lisp
+++ b/tutorial/19-tutorial.lisp
@@ -10,6 +10,7 @@
 ;;; collapsible trees that we will use for this tutorial.
 
 (defun on-new-window (body)
+  (setf (title (html-document body)) "Tutorial 19") ;; set the page title
   ;; First we need to load jslists' JavaScript file and css
   (load-css (html-document body) "/tutorial/jslists/jsLists.css")
   (load-script (html-document body) "/tutorial/jslists/jsLists.js")

--- a/tutorial/20-tutorial.lisp
+++ b/tutorial/20-tutorial.lisp
@@ -54,6 +54,7 @@
 (in-package :clog-tut-20)
 
 (defun on-new-window (body)
+  (setf (title (html-document body)) "Tutorial 20") ;; set the page title
   (clog-toggler:init-toggler body)
   ;; Now we build our CLOG-Toggler
   ;; All create-functions also allow setting the :html-id instead of

--- a/tutorial/21-tutorial.lisp
+++ b/tutorial/21-tutorial.lisp
@@ -50,6 +50,7 @@ on the drop-root."))
 (in-package :clog-tut-21)
 
 (defun on-new-window (body)
+  (setf (title (html-document body)) "Tutorial 21") ;; set the page title
   (let* ((drop-list  (clog-drop-list:create-drop-list body :content "Top of tree"))
          (item (create-list-item (clog-drop-list:drop-root drop-list) :content "Item 1"))
          (item (create-list-item (clog-drop-list:drop-root drop-list) :content "Item 2"))

--- a/tutorial/27-tutorial.lisp
+++ b/tutorial/27-tutorial.lisp
@@ -7,6 +7,7 @@
 (in-package :clog-tut-27)
 
 (defun on-new-window (body)
+  (setf (title (html-document body)) "Tutorial 27") ;; set the page title
   (let* ((console (create-panel-box-layout body :left-width 200 :right-width 0))
          (head    (create-div (top-panel console) :content "Image Viewer"))
          (lbox    (create-select (left-panel console)))

--- a/tutorial/29-tutorial.lisp
+++ b/tutorial/29-tutorial.lisp
@@ -12,6 +12,7 @@
    (my-count :accessor my-count :initform 500)))
 
 (defun on-new-window (body)
+  (setf (title (html-document body)) "Tutorial 29") ;; set the page title
   (let* ((lisp-obj (make-instance 'my-class))
          (i1 (create-form-element body :text
                                   :label (create-label body :content "Form value:")))

--- a/tutorial/30-tutorial.lisp
+++ b/tutorial/30-tutorial.lisp
@@ -12,6 +12,7 @@
 
 (defun init-site (body)
   (clog-web-initialize body)
+  (setf (title (html-document body)) "Tutorial 30") ;; set the page title
   (create-web-site body
                    ;; use the default theme
                    :theme 'clog-web:default-theme

--- a/tutorial/31-tutorial.lisp
+++ b/tutorial/31-tutorial.lisp
@@ -66,6 +66,7 @@
   "Setup the website, called on each url switch"
   ;; Initialize the clog-web environment
   (clog-web-initialize body)
+  (setf (title (html-document body)) "Tutorial 31") ;; set the page title
   ;; Instantly reload other windows open on authentication change
   (set-on-authentication-change body (lambda (body)
                                        (url-replace (location body) "/")))

--- a/tutorial/32-tutorial.lisp
+++ b/tutorial/32-tutorial.lisp
@@ -88,6 +88,7 @@
   "Setup the website, called on each url switch"
   ;; Initialize the clog-web environment
   (clog-web-initialize body)
+  (setf (title (html-document body)) "Tutorial 32") ;; set the page title
   ;; Instantly reload other windows open on authentication change
   (set-on-authentication-change body (lambda (body)
                                        (url-replace (location body) "/")))


### PR DESCRIPTION
When I was quickly loading tutorials it was hard to visually tell which tab was which tutorial because not all tutorials had the page title included.  I went through all the tutorials and made sure each one had a standardized title for ease of use.