### PR TITLE
Introduce a new low level creation for clog element: 'create-element' 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 *.wx32fsl
 *~
 *.bak
+*.64yfasl

--- a/source/clog-element.lisp
+++ b/source/clog-element.lisp
@@ -72,6 +72,33 @@ CONNECTION-ID to it and then return it. The HTML-ID must be unique. (private)"
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;
+;; create-element ;;
+;;;;;;;;;;;;;;;;;;
+(defgeneric create-element (clog-obj html-tag &rest all-args &key content clog-type html-id
+                                                                  auto-place &allow-other-keys )
+  (:documentation "Create a new CLOG-element as child of CLOG-OBJ with any possible keywords.")
+  (:method (clog-obj html-tag &rest all-args &key (content "")
+                                                  clog-type
+                                                  (html-id (clog-connection:generate-id))
+                                                  (auto-place t)
+                              &allow-other-keys )
+    (let* ((extra-args (alexandria:remove-from-plist all-args :content :clog-type :html-id :auto-place))
+           (html (with-output-to-string (*standard-output*)
+                   (format t "<~(~a~) " html-tag)
+                   (loop for (key value) on extra-args by #'cddr
+                         do (format t "~(~a~)=~s" key value))
+                   (format t " id=~s>~A</~(~a~)>" html-id content html-tag)))
+           (clog-type (or clog-type
+                          (let* ((class-name (intern (string-upcase (format nil "CLOG-~a" html-tag)) :clog)))
+                            (when (find-class class-name nil)
+                              class-name))
+                          'clog-element)))
+      (create-child clog-obj html
+                    :clog-type  clog-type
+                    :html-id    html-id
+                    :auto-place auto-place))))
+
+;;;;;;;;;;;;;;;;;;
 ;; create-child ;;
 ;;;;;;;;;;;;;;;;;;
 

--- a/source/clog.lisp
+++ b/source/clog.lisp
@@ -201,6 +201,7 @@ embedded in a native template application.)"
   (clog-element class)
 
   "CLOG-Element - Low Level Creation"
+  (create-element  generic-function)
   (create-child    generic-function)
   (attach-as-child generic-function)
 


### PR DESCRIPTION
It is useful to integrate with bootstrap, for example:
```lisp
(create-element toolbar-row :div :class "btn-toolbar" :role "toolbar" :aria-label "Toolbar")
```
Or:
```lisp
(create-element toolbar-group-1 :button :content "F" :class "btn btn-primary" :title "a tooltip for a button")
```