### PR TITLE
Fix for CCL on Windows: 'windows' feature to clog-connection

### DIFF
--- a/source/clog-connection.lisp
+++ b/source/clog-connection.lisp
@@ -90,7 +90,7 @@ script."
 
 (defvar *new-id* '(0) "Last issued connection or script IDs")
 
-#-(or mswindows win32 cormanlisp) ; isaac hasn't supported these platforms
+#-(or mswindows windows win32 cormanlisp) ; isaac hasn't supported these platforms
 (defparameter *isaac-ctx*
   (isaac:init-self-seed :count 5
                         :is64 #+:X86-64 t #-:X86-64 nil)
@@ -133,10 +133,10 @@ script."
 
 (defun random-hex-string ()
   "Generate cryptographic grade random ids for use in connections."
-  #+(or mswindows win32 cormanlisp) ; isaac hasn't supported these platforms. Use ironclad instead.
+  #+(or mswindows windows win32 cormanlisp) ; isaac hasn't supported these platforms. Use ironclad instead.
   (ironclad:byte-array-to-hex-string
     (ironclad:random-data 16))
-  #-(or mswindows win32 cormanlisp) ; isaac hasn't supported these platforms
+  #-(or mswindows windows win32 cormanlisp) ; isaac hasn't supported these platforms
   (format nil "~(~32,'0x~)" (#+:X86-64 isaac:rand-bits-64
                              #-:X86-64 isaac:rand-bits
                              *isaac-ctx* 128)))


### PR DESCRIPTION
Hello,

Clozure CL (at least in current version - 1.12.1) doesn't add `mswindows` or `win32` into *features* by default, they add `windows`.

```
CL-USER> (member :windows *features*)
(:WINDOWS :LITTLE-ENDIAN-TARGET :LITTLE-ENDIAN-HOST)
CL-USER> (member :win32 *features*)
NIL
CL-USER> (member :mswindows *features*)
NIL
CL-USER> (lisp-implementation-type)
"Clozure Common Lisp"
CL-USER> (lisp-implementation-version)
"Version 1.12.2 (v1.12.2) WindowsX8664"
```

Could you add `windows` into `clog-connection` to make it loadable on CCL on Windows, please? Otherwise loading CLOG fails that `cl-isaac` can't find `/dev/arandom` or `/dev/urandom`. (I can confirm that this is no issue on SBCL on Windows in 2.3.2 and 2.4.1 and on SBCL on Windows/WSL 2.4.1 and 2.4.2).