### PR TITLE
Add ability to handle wheel events with clog:set-on-wheel

### DIFF
--- a/source/clog-base.lisp
+++ b/source/clog-base.lisp
@@ -347,6 +347,24 @@ result or if time out DEFAULT-ANSWER. see JQUERY-QUERY (Internal)"))
       :meta-key     (js-true-p (nth 6 f))
       :drag-data    (quri:url-decode (or (nth 7 f) "")))))
 
+;;;;;;;;;;;;;;;;;;;;;;;
+;; parse-wheel-event ;;
+;;;;;;;;;;;;;;;;;;;;;;;
+
+(defparameter wheel-event-script
+  "+ e.originalEvent.deltaX + ':' + e.originalEvent.deltaY + ':' + e.originalEvent.deltaZ +
+':' + e.originalEvent.deltaMode"
+  "JavaScript to collect wheel event data from browser.")
+
+(defun parse-wheel-event (data)
+  (let ((f (ppcre:split ":" data)))
+    (list
+     :event-type :wheel
+     :delta-x (js-to-float (nth 0 f))
+     :delta-y (js-to-float (nth 1 f))
+     :delta-z (js-to-float (nth 2 f))
+     :delta-mode (js-to-integer (nth 3 f)))))
+
 ;;;;;;;;;;;;;;;
 ;; set-event ;;
 ;;;;;;;;;;;;;;;
@@ -1061,6 +1079,25 @@ ON-MOUSE-MOVE-HANDLER is nil unbind the event."))
              :one-time one-time
              :cancel-event cancel-event
              :call-back-script mouse-event-script))
+
+;;;;;;;;;;;;;;;;;;
+;; set-on-wheel ;;
+;;;;;;;;;;;;;;;;;;
+
+(defgeneric set-on-wheel (clog-obj on-wheel-handler
+			  &key one-time cancel-event)
+  (:documentation "Set the ON-WHEEL-HANDLER for CLOG-OBJ. If
+ON-WHEEL-HANDLER is nil unbind the event."))
+
+(defmethod set-on-wheel ((obj clog-obj) handler
+			 &key (one-time nil) (cancel-event nil))
+  (set-event obj "wheel"
+	     (when handler
+	       (lambda (data)
+		 (funcall handler obj (parse-wheel-event data))))
+	     :one-time one-time
+	     :cancel-event cancel-event
+	     :call-back-script wheel-event-script))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; set-on-pointer-enter ;;

--- a/source/clog.lisp
+++ b/source/clog.lisp
@@ -191,6 +191,7 @@ embedded in a native template application.)"
   (set-on-mouse-down         generic-function)
   (set-on-mouse-up           generic-function)
   (set-on-mouse-move         generic-function)
+  (set-on-wheel              generic-function)
   (set-on-pointer-enter      generic-function)
   (set-on-pointer-leave      generic-function)
   (set-on-pointer-over       generic-function)

--- a/test/test-clog.lisp
+++ b/test/test-clog.lisp
@@ -45,6 +45,12 @@
                        (lambda (obj data)
                          (declare (ignore obj))
                          (format t "x=~A Y=~A~%" (getf data ':x) (getf data ':y))))
+    (set-on-wheel *last-obj*
+		  (lambda (obj data)
+		    (declare (ignore obj))
+		    (format t "delta-x=~A delta-y=~A~%"
+			    (getf data ':delta-x)
+			    (getf data ':delta-y))))
     (set-on-key-down win
                       (lambda (obj data)
                         (declare (ignore obj))


### PR DESCRIPTION
While working on a project, I needed to capture mouse wheel events. I did not find the needed functions in clog, therefore I rolled my own implementation, which I contribute here.

The wheel event reports the following data: `delta-x`, `delta-y`, `delta-z`, `delta-mode` (I based myself on https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event).

I added a test on the "********" button of `test-clog:on-new-window`: scrolling the button prints `delta-x` and `delta-y`. 