### PR TITLE
Make web auth token more secure

### DIFF
--- a/source/clog-web-dbi.lisp
+++ b/source/clog-web-dbi.lisp
@@ -196,7 +196,8 @@ if one is present and login fails."
 
 (defun make-token ()
   "Create a unique token used to associate a browser with a user"
-  (get-universal-time))
+  (crypto:byte-array-to-hex-string
+   (crypto:random-data 16)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;
 ;; create-base-table ;;


### PR DESCRIPTION
The current way web tokens are made would allow the hacker to spoof a login of another user by guessing the time which the token was created.   This change makes the token a crypto random 128 bit string which is much harder to guess.