### PR TITLE
fix: misspelling of "tutorial" in various files

### DIFF
--- a/tutorial/01-tutorial.lisp
+++ b/tutorial/01-tutorial.lisp
@@ -34,7 +34,7 @@
 ;;; exist, take a look through the CLOG manual or the file clog-element.lisp
 
 (defun start-tutorial ()   ; Define the function called start-tutorial
-  "Start turtorial."       ; Optional docstring to describe function
+  "Start tutorial."       ; Optional docstring to describe function
 
   ;; Initialize the CLOG system
   (initialize #'on-new-window)

--- a/tutorial/02-tutorial.lisp
+++ b/tutorial/02-tutorial.lisp
@@ -36,6 +36,6 @@
                         (scroll-to (window body) 0 (height body))))))))
 
 (defun start-tutorial ()
-  "Start turtorial."
+  "Start tutorial."
   (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/03-tutorial.lisp
+++ b/tutorial/03-tutorial.lisp
@@ -31,6 +31,6 @@
 ;;; But... notice what happens once syncing is on the next event doesn't hit until
 ;;; SLEEP returns.
 (defun start-tutorial ()
-  "Start turtorial."
+  "Start tutorial."
   (initialize 'on-new-window)
   (open-browser))

--- a/tutorial/24-tutorial.lisp
+++ b/tutorial/24-tutorial.lisp
@@ -97,7 +97,7 @@
     (create-web-code main :content
                      ";; This is a code block<br>
                       (defun start-tutorial ()<br>
-                      \"Start turtorial.\"<br>
+                      \"Start tutorial.\"<br>
                       (initialize 'on-new-window)<br>
                       (open-browser))")))
 


### PR DESCRIPTION
Similar to #399 but that merge missed some.