### PR TITLE
Fix typos in QLOT.md and OCICL.md

### DIFF
--- a/OCICL.md
+++ b/OCICL.md
@@ -10,7 +10,7 @@ add them to your asd file and will be downloaded as needed. A simple
 run of "ocicl latest" updates your project dependecies.
 
 Once installed either in an empty new project dir or existing project do:
-(Do not call your project clog, that creates an asdf circular dependecy.)
+(Do not call your project clog, that creates an asdf circular dependency.)
 
 ```
 ocicl setup > init

--- a/QLOT.md
+++ b/QLOT.md
@@ -23,7 +23,7 @@ Create a file call qlfile with:
 dist http://dist.ultralisp.org/
 ```
 
-(I am using the REPL method for maximum compatability, if you alredy know
+(I am using the REPL method for maximum compatibility, if you already know
 qlot you can use the command line tool if you have installed it.)
 
 run sbcl and type:


### PR DESCRIPTION
Fixes 3 typos:
- `QLOT.md:26` `compatability` -> `compatibility`
- `QLOT.md:26` `alredy` -> `already` (same line)
- `OCICL.md:13` `dependecy` -> `dependency`