### PR TITLE
Replace cl-isaac with ironclad for connection ID generation

### DIFF
--- a/clog.asd
+++ b/clog.asd
@@ -16,7 +16,7 @@
                        #:bordeaux-threads #:parse-float #:quri #:clack-handler-hunchentoot
                        #:lack-middleware-static #:lack-request #:lack-util-writer-stream
                        #:trivial-gray-streams #:closer-mop #:mgl-pax #:cl-template #:atomics
-                       #:sqlite #:cl-dbi #:cl-pass #-(or mswindows win32 cormanlisp) #:cl-isaac)
+                       #:sqlite #:cl-dbi #:cl-pass #:ironclad)
   :components ((:module "static-files"
                 :components ((:static-file "js/boot.js")))
                (:module "source"

--- a/source/clog-connection.lisp
+++ b/source/clog-connection.lisp
@@ -106,13 +106,6 @@ script."
 
 (defvar *new-id* '(0) "Last issued connection or script IDs")
 
-#-(or mswindows windows win32 cormanlisp) ; isaac hasn't supported these platforms
-(defparameter *isaac-ctx*
-  (isaac:init-self-seed :count 5
-                        :is64 #+:X86-64 t #-:X86-64 nil)
-  "A ISAAC::ISAAC-CTX. Or, a ISAAC::ISAAC64-CTX on X86-64. It will be used to
-generate random hex strings for connection IDs")
-
 (defvar *queries*        (make-hash-table*) "Query ID to Answers")
 (defvar *queries-sems*   (make-hash-table*) "Query ID to semiphores")
 (defvar *query-time-out* 3
@@ -134,13 +127,8 @@ generate random hex strings for connection IDs")
 
 (defun random-hex-string ()
   "Generate cryptographic grade random ids for use in connections."
-  #+(or mswindows windows win32 cormanlisp) ; isaac hasn't supported these platforms. Use ironclad instead.
   (ironclad:byte-array-to-hex-string
-    (ironclad:random-data 16))
-  #-(or mswindows windows win32 cormanlisp) ; isaac hasn't supported these platforms
-  (format nil "~(~32,'0x~)" (#+:X86-64 isaac:rand-bits-64
-                             #-:X86-64 isaac:rand-bits
-                             *isaac-ctx* 128)))
+    (ironclad:random-data 16)))
 
 ;;;;;;;;;;;;;;;;;;;;
 ;; get-connection ;;


### PR DESCRIPTION
I ran into this issue with sbcl declaim safety 2 and patched my project by overriding clog-connection::random-hex-string. Claude's diagnosis is below.

## The bug

`cl-isaac`'s `rand32` unconditionally `decf`s its `randcnt` slot
(declared `(unsigned-byte 32)`) *before* checking whether the
256-word ISAAC block is exhausted:

```lisp
(defun rand32 (ctx)
  (let ((c (isaac-ctx-randcnt ctx)))
    (decf (isaac-ctx-randcnt ctx))       ; <- unconditional, underflows 0 -> -1
    (if (zerop c)
        (progn (generate-next-isaac-block ctx)
               (setf (isaac-ctx-randcnt ctx) 255)
               (aref (isaac-ctx-randrsl ctx) 255))
        (aref (isaac-ctx-randrsl ctx) (isaac-ctx-randcnt ctx)))))
```

cl-isaac compiles its own `isaac-32.lisp` under `(safety 2)` (set in
`make.lisp`), so SBCL's typed-slot writer raises `TYPE-ERROR` on the
underflow, unwinding `rand32` *before* the `(if (zerop c) ...)` reset
branch ever runs. `randcnt` stays at 0 and the PRNG is permanently
wedged — every subsequent call traps in the same place.

## How it manifests in CLOG

`clog-connection::random-hex-string` throws inside
`handle-new-connection`. The surrounding `handler-case` swallows the
error, the WebSocket upgrade completes, but the
`(websocket-driver:send connection "clog['connection_id']='…'")` and
the on-connect thread spawn never run — so the server sends 0 bytes
after the 101 handshake and the browser sits on an unbootstrapped body
forever. Restarting "fixes" it briefly because `*isaac-ctx*` is
restored from the `save-lisp-and-die` image with a non-zero `randcnt`;
after one ISAAC block (~256 connections) it wedges again.

Upstream is unresponsive — issue and PR open since 2023:

- https://github.com/thephoeron/cl-isaac/issues/12
- https://github.com/thephoeron/cl-isaac/pull/13

## The fix

CLOG already called `ironclad:byte-array-to-hex-string` +
`ironclad:random-data` on the Windows branch of `random-hex-string`,
and `cl-pass` (already a direct dep) pulls `ironclad` in transitively.
This PR:

- drops `cl-isaac` from `clog.asd` and declares `ironclad` explicitly,
- removes the `*isaac-ctx*` defparameter (not exported — verified
  against the `defsection @clog-connection` export list),
- collapses `random-hex-string` to a single platform-agnostic body
  using the existing ironclad codepath.

Output contract is preserved: 32 lowercase hex chars (16 octets from
ironclad's default OS PRNG — `/dev/urandom` on Unix,
`CryptGenRandom` on Windows).

## Verification

Loaded `:clog` clean in SBCL 2.5.2, then:

```lisp
(every (lambda (s) (= 32 (length s)))
       (loop repeat 10000 collect (clog-connection:random-hex-string)))
;; => T
```

— would have wedged the old cl-isaac path after ~256 calls under
`(safety 2)`.